### PR TITLE
bind every portion of GPU not just video and audio

### DIFF
--- a/vfio-pci-override-vga.sh
+++ b/vfio-pci-override-vga.sh
@@ -1,17 +1,14 @@
 #!/bin/sh
 
-for i in /sys/bus/pci/devices/*/boot_vga; do
+for i in /sys/bus/pci/devices/*/boot_vga
+do
     if [ $(cat "$i") -eq 0 ]; then
         GPU="${i%/boot_vga}"
-        AUDIO="$(echo "$GPU" | sed -e "s/0$/1/")"
-        echo "vfio-pci" > "$GPU/driver_override"
-	BIND_GPU=`echo "$GPU" | cut -d '/' -f 6`
-	echo "$BIND_GPU" >> /sys/bus/pci/drivers/vfio-pci/bind
-        if [ -d "$AUDIO" ]; then
-        echo "vfio-pci" > "$AUDIO/driver_override"
-	BIND_AUDIO=`echo "$AUDIO" | cut -d '/' -f 6`
-	echo "$BIND_AUDIO" >> /sys/bus/pci/drivers/vfio-pci/bind
-        fi
+        for part in `ls -d $(echo $GPU | cut -f1 -d'.').*`
+        do
+            echo "vfio-pci" > "$part/driver_override"
+            BIND_DEVICE=`echo "$part" | cut -d '/' -f 6`
+            echo "$BIND_DEVICE" >> /sys/bus/pci/drivers/vfio-pci/bind
+        done
     fi
 done
-


### PR DESCRIPTION
I modified the init-top script that not only video and audio controller would be bind to vfio but all portions. For a 16xx nvidia GPU (or newer) I can see 4 portions and I have to passthrough each to the guest.

```
Group:  16  0000:0a:00.0 VGA compatible controller [0300]: NVIDIA Corporation TU116 [GeForce GTX 1660 SUPER] [10de:21c4] (rev a1)   Driver: vfio-pci
Group:  16  0000:0a:00.1 Audio device [0403]: NVIDIA Corporation TU116 High Definition Audio Controller [10de:1aeb] (rev a1)   Driver: vfio-pci
Group:  16  0000:0a:00.2 USB controller [0c03]: NVIDIA Corporation TU116 USB 3.1 Host Controller [10de:1aec] (rev a1)   Driver: vfio-pci
Group:  16  0000:0a:00.3 Serial bus controller [0c80]: NVIDIA Corporation TU116 [GeForce GTX 1650 SUPER] [10de:1aed] (rev a1)   Driver: vfio-pci
Group:  17  0000:0b:00.0 VGA compatible controller [0300]: NVIDIA Corporation GP107 [GeForce GTX 1050 Ti] [10de:1c82] (rev a1)   Driver: nouveau
Group:  17  0000:0b:00.1 Audio device [0403]: NVIDIA Corporation GP107GL High Definition Audio Controller [10de:0fb9] (rev a1)   Driver: snd_hda_intel
```